### PR TITLE
- Added currentPage var of ProgressPageControl as 'open'

### DIFF
--- a/Source/UIComponents/ProgressPageControl/ProgressPageControl.swift
+++ b/Source/UIComponents/ProgressPageControl/ProgressPageControl.swift
@@ -31,7 +31,7 @@ import UIKit
     /// To set the current page
     ///
     /// - Since: 2.3
-    var currentPage: Int = 0 {
+    open var currentPage: Int = 0 {
         didSet {
             if self.currentPage > (self.numberOfPages - 1) {
                 LogWarn("You cannot set the current page greater than numberOfPages")


### PR DESCRIPTION
I forgot to set this variable as 'open' and you can't access to it to change the current page.