### PR TITLE
Improve images downloader utility

### DIFF
--- a/Source/GIGUtils/Image/ImageDownloader.swift
+++ b/Source/GIGUtils/Image/ImageDownloader.swift
@@ -61,7 +61,7 @@ struct ImageDownloader {
 			switch response.status {
 				
 			case .success:
-				DispatchQueue(label: "com.gigigo.imagedownloader", qos: .background).async {
+				DispatchQueue.global().async {
 					if let image = try? response.image() {
 						let width = view.width() * UIScreen.main.scale
 						let height = view.height() * UIScreen.main.scale


### PR DESCRIPTION
Change queue that resize the images in image downloader to global queue in order to prevent errors