### PR TITLE
Fix: ImageDownloader reset refactor

### DIFF
--- a/Source/GIGUtils/Image/ImageDownloader.swift
+++ b/Source/GIGUtils/Image/ImageDownloader.swift
@@ -18,9 +18,9 @@ struct ImageDownloader {
 	
 	private init() {
 		NotificationCenter.default.addObserver(forName: .UIApplicationDidReceiveMemoryWarning, object: nil, queue: nil) { _ in
-			ImageDownloader.images.removeAll()
-			ImageDownloader.stack.removeAll()
-			ImageDownloader.queue.removeAll()
+			ImageDownloader.images = [:]
+			ImageDownloader.stack = []
+			ImageDownloader.queue = [:]
 		}
 	}
 	


### PR DESCRIPTION
Tenemos un bug con un "bad access" en ImageDownloader. En principio es un "bad access" al intentar a un puntero ya eliminado.
Hay una suscripción a una notificación de falta de memoria que hace un "removeAll" de todos los arrays y diccionarios de la clase. Este metodo borra todas la referencias a sus elementos. Es posible que en ese momento se estuviera usando alguno de ellos en otro hilo.
No estoy seguro, pero es posible que la modificación de código no elimine los punteros en uso.