### PR TITLE
Fix: Release/v3.0.23 with SlideMenu preferredStatusBarStyle support

### DIFF
--- a/App/Main/GLAMainViewController.m
+++ b/App/Main/GLAMainViewController.m
@@ -18,12 +18,21 @@
 
 @implementation GLAMainViewController
 
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+}
+
 - (void)motionEnded:(UIEventSubtype)motion withEvent:(UIEvent *)event
 {
     if (motion == UIEventSubtypeMotionShake)
     {
         [[GIGURLManager sharedManager] showConfig];
     }
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return UIStatusBarStyleDefault;
 }
 
 @end

--- a/App/Main/Main.storyboard
+++ b/App/Main/Main.storyboard
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="3ms-yN-F2o">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.15" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="3ms-yN-F2o">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.9"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Navigation Controller-->
+        <!--Main Navigation View Controller-->
         <scene sceneID="nm9-da-Xc4">
             <objects>
-                <navigationController id="3ms-yN-F2o" sceneMemberID="viewController">
+                <navigationController id="3ms-yN-F2o" customClass="MainNavigationViewController" sceneMemberID="viewController">
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="BUb-tV-UKU">
                         <rect key="frame" x="0.0" y="20" width="375" height="44"/>
@@ -25,7 +24,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ETg-2q-d2s" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-987" y="1324"/>
+            <point key="canvasLocation" x="-1579.2" y="1191.0044977511245"/>
         </scene>
         <!--Screen RecordVC-->
         <scene sceneID="90x-ml-hDM">
@@ -40,13 +39,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Screen record" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ec2-dC-SjP">
-                                <rect key="frame" x="134" y="28" width="108" height="21"/>
+                                <rect key="frame" x="133.5" y="28" width="108" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B88-Nu-VNj">
-                                <rect key="frame" x="137" y="78" width="100" height="50"/>
+                                <rect key="frame" x="137.5" y="78" width="100" height="50"/>
                                 <color key="backgroundColor" red="0.87450980389999999" green="0.87843137250000003" blue="0.87450980389999999" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="SWW-AR-Bym"/>
@@ -58,7 +57,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VwQ-uF-xuz">
-                                <rect key="frame" x="137" y="158" width="100" height="50"/>
+                                <rect key="frame" x="137.5" y="158" width="100" height="50"/>
                                 <color key="backgroundColor" red="0.87450980389999999" green="0.87843137250000003" blue="0.87450980389999999" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="Zl0-E8-pY3"/>
@@ -70,7 +69,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tRR-93-l7o">
-                                <rect key="frame" x="137" y="238" width="100" height="50"/>
+                                <rect key="frame" x="137.5" y="238" width="100" height="50"/>
                                 <color key="backgroundColor" red="0.87450980389999999" green="0.87843137250000003" blue="0.87450980389999999" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="100" id="C7G-5u-6dw"/>
@@ -101,7 +100,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="g3W-hG-Bly" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="738" y="1735"/>
+            <point key="canvasLocation" x="1180.8" y="1560.7196401799101"/>
         </scene>
         <!--LocationVC-->
         <scene sceneID="zHM-h3-TOg">
@@ -139,7 +138,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="PTI-yk-QKW" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-1285" y="2536"/>
+            <point key="canvasLocation" x="-2056" y="2281.2593703148427"/>
         </scene>
         <!--Infinite CollectionVC-->
         <scene sceneID="hLl-kl-9M0">
@@ -175,7 +174,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="QHN-Zn-T8d" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-825.5" y="2535.5"/>
+            <point key="canvasLocation" x="-1320.8" y="2280.8095952023991"/>
         </scene>
         <!--ProgressVC-->
         <scene sceneID="UNl-uj-4Yy">
@@ -205,7 +204,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ydU-FA-7CE">
-                                <rect key="frame" x="158.5" y="461" width="57" height="30"/>
+                                <rect key="frame" x="159" y="461" width="57" height="30"/>
                                 <state key="normal" title="Animate"/>
                                 <connections>
                                     <action selector="animateProgressWithSender:" destination="g0j-si-aRe" eventType="touchUpInside" id="Y8O-qc-TCR"/>
@@ -219,7 +218,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BVO-71-R0T">
-                                <rect key="frame" x="152" y="377" width="70" height="30"/>
+                                <rect key="frame" x="152.5" y="377" width="70" height="30"/>
                                 <state key="normal" title="Next page"/>
                                 <connections>
                                     <action selector="nextPageWithSender:" destination="g0j-si-aRe" eventType="touchUpInside" id="hLu-r6-hqH"/>
@@ -244,7 +243,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="w2D-Q1-WKE" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-383" y="2536"/>
+            <point key="canvasLocation" x="-612.79999999999995" y="2281.2593703148427"/>
         </scene>
         <!--Slide Menu View Controller-->
         <scene sceneID="03O-tP-xnJ">
@@ -289,7 +288,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Dh7-5S-atd" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="40" y="2536"/>
+            <point key="canvasLocation" x="64" y="2281.2593703148427"/>
         </scene>
         <!--KeyboardVC-->
         <scene sceneID="LCd-PK-gUd">
@@ -349,12 +348,12 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RQR-fB-lRX" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="40" y="3331"/>
+            <point key="canvasLocation" x="64" y="2996.4017991004498"/>
         </scene>
-        <!--View Controller-->
+        <!--Slide Menu Section1VC-->
         <scene sceneID="Phr-fI-NYs">
             <objects>
-                <viewController storyboardIdentifier="SlideMenuSection1" id="Ogw-Q3-AGa" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SlideMenuSection1" id="Ogw-Q3-AGa" customClass="SlideMenuSection1VC" customModule="GIGLibraryApp" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="jI2-8w-OCG"/>
                         <viewControllerLayoutGuide type="bottom" id="Kqj-tM-jCa"/>
@@ -380,7 +379,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="JJd-fw-XlS" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="469" y="2536"/>
+            <point key="canvasLocation" x="750.39999999999998" y="2281.2593703148427"/>
         </scene>
         <!--Alert View Controller-->
         <scene sceneID="krt-q2-aol">
@@ -399,7 +398,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="XP4-QR-pef" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="256" y="771"/>
+            <point key="canvasLocation" x="409.60000000000002" y="693.55322338830592"/>
         </scene>
         <!--Swift Requests-->
         <scene sceneID="bT5-WV-PrD">
@@ -467,7 +466,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="mfp-7g-cSr" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="507.5" y="-890.5"/>
+            <point key="canvasLocation" x="812" y="-801.0494752623689"/>
         </scene>
         <!--Example Form-->
         <scene sceneID="Slv-dI-SNS">
@@ -536,7 +535,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="WCB-KT-keV" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="45" y="-154"/>
+            <point key="canvasLocation" x="72" y="-138.53073463268368"/>
         </scene>
         <!--GIGLibrary-->
         <scene sceneID="JbR-H5-Et5">
@@ -794,11 +793,11 @@
                                         <rect key="frame" x="0.0" y="660" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Byq-LD-ydM" id="Sri-Jp-13e">
-                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Screen Recording View" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ixE-gJ-oRP" userLabel="Alert">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="43.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="325" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -818,7 +817,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="hNX-dj-yYP" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-529" y="1324"/>
+            <point key="canvasLocation" x="-846.39999999999998" y="1191.0044977511245"/>
         </scene>
         <!--QRVC-->
         <scene sceneID="tQG-7Z-zjd">
@@ -867,7 +866,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="EjX-z4-N2W" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="256" y="1535"/>
+            <point key="canvasLocation" x="409.60000000000002" y="1380.8095952023989"/>
         </scene>
         <!--MultiRequest-->
         <scene sceneID="CPb-rf-fNs">
@@ -899,12 +898,12 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="GGB-Dq-EKd" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="45" y="-890"/>
+            <point key="canvasLocation" x="72" y="-800.59970014992507"/>
         </scene>
-        <!--View Controller-->
+        <!--Slide Menu Section2VC-->
         <scene sceneID="vOE-uI-eLp">
             <objects>
-                <viewController storyboardIdentifier="SlideMenuSection2" id="Pnc-p5-W1v" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SlideMenuSection2" id="Pnc-p5-W1v" customClass="SlideMenuSection2VC" customModule="GIGLibraryApp" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="yWX-Yn-ywI"/>
                         <viewControllerLayoutGuide type="bottom" id="2Sw-ia-2Um"/>
@@ -929,7 +928,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="HDY-2a-0Oo" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="883" y="2536"/>
+            <point key="canvasLocation" x="1412.8" y="2281.2593703148427"/>
         </scene>
     </scenes>
 </document>

--- a/App/Main/MainNavigationViewController.h
+++ b/App/Main/MainNavigationViewController.h
@@ -1,0 +1,17 @@
+//
+//  MainNavigationViewController.h
+//  GIGLibraryApp
+//
+//  Created by Jerilyn Goncalves on 22/10/2018.
+//  Copyright © 2018 Gigigo SL. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MainNavigationViewController : UINavigationController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/App/Main/MainNavigationViewController.m
+++ b/App/Main/MainNavigationViewController.m
@@ -1,0 +1,29 @@
+//
+//  MainNavigationViewController.m
+//  GIGLibraryApp
+//
+//  Created by Jerilyn Goncalves on 22/10/2018.
+//  Copyright © 2018 Gigigo SL. All rights reserved.
+//
+
+#import "MainNavigationViewController.h"
+
+@interface MainNavigationViewController ()
+
+@end
+
+@implementation MainNavigationViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    if (self.topViewController != nil) {
+        return self.topViewController.preferredStatusBarStyle;
+    } else {
+        return UIStatusBarStyleDefault;
+    }
+}
+@end

--- a/App/Menu/SlideMenuViewController.swift
+++ b/App/Menu/SlideMenuViewController.swift
@@ -37,6 +37,9 @@ class SlideMenuViewController: UIViewController {
         self.menu.userDidTapMenu()
     }
 
+    override var preferredStatusBarStyle:  UIStatusBarStyle  {
+        return self.childViewControllers.first?.preferredStatusBarStyle ?? .default
+    }
     
     fileprivate func prepareMenu() {
         

--- a/App/Network/SwiftRequestVC.swift
+++ b/App/Network/SwiftRequestVC.swift
@@ -19,18 +19,18 @@ class SwiftRequestVC: UIViewController {
 	}
 	
 	@IBAction func onButtonSwiftRequestTap(_ sender: UIButton) {
-		let request = Request(
-			method: "POST",
-			baseUrl: "https://api-discover-mcd.q.gigigoapps.com",
-			endpoint: "/configuration",
-			headers: [
-				"x-app-version": "IOS_2.1",
-				"x-app-country": "BR",
-				"x-app-language": "es",
-			]
-		)
-		request.verbose = true
-		
+        var url = URL(string: "https://api-discover-mcd.q.gigigoapps.com")!
+        url.appendPathComponent("configuration")
+        
+        let request = Request(method: "POST",
+                          completeURL: url,
+                          headers: [
+                            "x-app-version": "IOS_2.1",
+                            "x-app-country": "BR",
+                            "x-app-language": "es",
+                            ])
+        request.verbose = true
+        
 		request.fetch(completionHandler: processResponse)
 	}
 	

--- a/App/Network/SwiftRequestVC.swift
+++ b/App/Network/SwiftRequestVC.swift
@@ -19,18 +19,20 @@ class SwiftRequestVC: UIViewController {
 	}
 	
 	@IBAction func onButtonSwiftRequestTap(_ sender: UIButton) {
-        var url = URL(string: "https://api-discover-mcd.q.gigigoapps.com")!
+        guard var url = URL(string: "https://api-discover-mcd.q.gigigoapps.com") else {
+            LogWarn("URL not valid")
+            return
+        }
         url.appendPathComponent("configuration")
         
         let request = Request(method: "POST",
-                          completeURL: url,
-                          headers: [
-                            "x-app-version": "IOS_2.1",
-                            "x-app-country": "BR",
-                            "x-app-language": "es",
-                            ])
+                              completeURL: url,
+                              headers: [
+                                "x-app-version": "IOS_2.1",
+                                "x-app-country": "BR",
+                                "x-app-language": "es"
+            ])
         request.verbose = true
-        
 		request.fetch(completionHandler: processResponse)
 	}
 	
@@ -141,9 +143,5 @@ class SwiftRequestVC: UIViewController {
 			Log("API error")
 			LogError(response.error)
 		}
-        
-
-        
 	}
-	
 }

--- a/App/SlideMenuSection1VC.swift
+++ b/App/SlideMenuSection1VC.swift
@@ -1,0 +1,16 @@
+//
+//  SlideMenuSection1VC.swift
+//  GIGLibrary
+//
+//  Created by Jerilyn Goncalves on 22/10/2018.
+//  Copyright © 2018 Gigigo SL. All rights reserved.
+//
+
+import UIKit
+
+class SlideMenuSection1VC: UIViewController {
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .default
+    }
+}

--- a/App/SlideMenuSection2VC.swift
+++ b/App/SlideMenuSection2VC.swift
@@ -1,0 +1,16 @@
+//
+//  SlideMenuSection2VC.swift
+//  GIGLibrary
+//
+//  Created by Jerilyn Goncalves on 22/10/2018.
+//  Copyright © 2018 Gigigo SL. All rights reserved.
+//
+
+import UIKit
+
+class SlideMenuSection2VC: UIViewController {
+ 
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+}

--- a/GIGLibraryApp/Info.plist
+++ b/GIGLibraryApp/Info.plist
@@ -2,12 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSCameraUsageDescription</key>
-	<string>camera</string>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string></string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
@@ -53,6 +47,12 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>camera</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string></string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string></string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -63,5 +63,7 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<true/>
 </dict>
 </plist>

--- a/GIGLibraryFramework/Info.plist
+++ b/GIGLibraryFramework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.22</string>
+	<string>3.0.23</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/GiGLibrary.xcodeproj/project.pbxproj
+++ b/GiGLibrary.xcodeproj/project.pbxproj
@@ -19,6 +19,9 @@
 		4A881C121C5F7C72000EC61E /* AlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A881C111C5F7C72000EC61E /* AlertController.swift */; };
 		4AACDF981C60DA2400F4E8AE /* ActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AACDF971C60DA2400F4E8AE /* ActionSheet.swift */; };
 		4AACDF9A1C611E7100F4E8AE /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AACDF991C611E7100F4E8AE /* Alert.swift */; };
+		616C53E4217E02E800A9013E /* SlideMenuSection1VC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616C53E0217E024600A9013E /* SlideMenuSection1VC.swift */; };
+		616C53E5217E02EB00A9013E /* SlideMenuSection2VC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616C53E2217E025100A9013E /* SlideMenuSection2VC.swift */; };
+		616C53E8217E082D00A9013E /* MainNavigationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 616C53E7217E082D00A9013E /* MainNavigationViewController.m */; };
 		617C5A601FBD7F69001DFCAC /* MultiDelegable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617C5A5F1FBD7F69001DFCAC /* MultiDelegable.swift */; };
 		618616A6208DEC4D001B4603 /* ExpandableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618616A4208DEC4D001B4603 /* ExpandableTextView.swift */; };
 		618616A7208DEC4D001B4603 /* ExpandableTextView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 618616A5208DEC4D001B4603 /* ExpandableTextView.xib */; };
@@ -370,6 +373,10 @@
 		4A881C111C5F7C72000EC61E /* AlertController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AlertController.swift; path = GIGUtils/AlertController/AlertController.swift; sourceTree = "<group>"; };
 		4AACDF971C60DA2400F4E8AE /* ActionSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ActionSheet.swift; path = ActionSheet/ActionSheet.swift; sourceTree = "<group>"; };
 		4AACDF991C611E7100F4E8AE /* Alert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Alert.swift; path = GIGUtils/AlertController/Alert.swift; sourceTree = "<group>"; };
+		616C53E0217E024600A9013E /* SlideMenuSection1VC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideMenuSection1VC.swift; sourceTree = "<group>"; };
+		616C53E2217E025100A9013E /* SlideMenuSection2VC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideMenuSection2VC.swift; sourceTree = "<group>"; };
+		616C53E6217E082D00A9013E /* MainNavigationViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MainNavigationViewController.h; sourceTree = "<group>"; };
+		616C53E7217E082D00A9013E /* MainNavigationViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MainNavigationViewController.m; sourceTree = "<group>"; };
 		617C5A5F1FBD7F69001DFCAC /* MultiDelegable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiDelegable.swift; sourceTree = "<group>"; };
 		618616A4208DEC4D001B4603 /* ExpandableTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExpandableTextView.swift; sourceTree = "<group>"; };
 		618616A5208DEC4D001B4603 /* ExpandableTextView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ExpandableTextView.xib; sourceTree = "<group>"; };
@@ -1407,6 +1414,8 @@
 				D99AD3601B1DAAE6005BB4E5 /* AppDelegate.h */,
 				D99AD3611B1DAAE6005BB4E5 /* AppDelegate.m */,
 				D99AD3621B1DAAE6005BB4E5 /* Main.storyboard */,
+				616C53E6217E082D00A9013E /* MainNavigationViewController.h */,
+				616C53E7217E082D00A9013E /* MainNavigationViewController.m */,
 				D99AD3631B1DAAE6005BB4E5 /* GLAMainViewController.h */,
 				D99AD3641B1DAAE6005BB4E5 /* GLAMainViewController.m */,
 			);
@@ -1705,6 +1714,8 @@
 			isa = PBXGroup;
 			children = (
 				FA133A731CBC21EE0007EE06 /* SlideMenuViewController.swift */,
+				616C53E0217E024600A9013E /* SlideMenuSection1VC.swift */,
+				616C53E2217E025100A9013E /* SlideMenuSection2VC.swift */,
 			);
 			name = Menu;
 			sourceTree = "<group>";
@@ -2349,10 +2360,13 @@
 			files = (
 				FA42A2AD1C6B678300C2D1BB /* SwiftRequestVC.swift in Sources */,
 				D99AD3741B1DAAE6005BB4E5 /* GLAMainViewController.m in Sources */,
+				616C53E5217E02EB00A9013E /* SlideMenuSection2VC.swift in Sources */,
 				FACE6D9B1BBC116B00457B4C /* GLAMultiRequestViewController.m in Sources */,
 				FA133A751CBC225E0007EE06 /* SlideMenuViewController.swift in Sources */,
+				616C53E4217E02E800A9013E /* SlideMenuSection1VC.swift in Sources */,
 				D99AD3761B1DAAE6005BB4E5 /* main.m in Sources */,
 				FA89A8C01D33BAC300AE6E3A /* QRVC.swift in Sources */,
+				616C53E8217E082D00A9013E /* MainNavigationViewController.m in Sources */,
 				FA56AFF51CDF323700ABDA53 /* KeyboardVC.swift in Sources */,
 				4A23B67B1C74779D00E37E5D /* (null) in Sources */,
 				FA6A3A351CD3B16000835521 /* GLABasicFormViewController.m in Sources */,

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.org/gigigoapps/gigigo-ios-lib.svg?branch=master)](https://travis-ci.org/gigigoapps/gigigo-ios-lib)
 ![Language](https://img.shields.io/badge/Language-Objective--C-orange.svg)
 ![Language](https://img.shields.io/badge/Language-Swift-orange.svg)
-![Version](https://img.shields.io/badge/version-3.0.22-blue.svg)
+![Version](https://img.shields.io/badge/version-3.0.23-blue.svg)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 

--- a/Source/GIGUtils/Image/ImageDownloader.swift
+++ b/Source/GIGUtils/Image/ImageDownloader.swift
@@ -57,17 +57,16 @@ struct ImageDownloader {
 		guard let view = ImageDownloader.stack.popLast() else { return }
 		guard let request = ImageDownloader.queue[view] else {
             self.downloadNext()
-            return }
+            return
+        }
 		
 		request.fetch { response in
 			switch response.status {
 				
 			case .success:
 				DispatchQueue.global().async {
-					if let image = try? response.image() {
-						
+					if let image = try? response.image() {						
 						DispatchQueue.main.sync {
-                            
                             let width = view.width() * UIScreen.main.scale
                             let height = view.height() * UIScreen.main.scale
                             let resized = image.imageProportionally(with: CGSize(width: width, height: height))
@@ -83,6 +82,7 @@ struct ImageDownloader {
 							self.downloadNext()
 						}
 					} else {
+                        LogWarn("Al descargar la imagen,o se ha recibido un body vacio o no se se ha reconocido el tipo de imagen que es.")
 						self.downloadNext()
 					}
 				}

--- a/Source/GIGUtils/Image/ImageDownloader.swift
+++ b/Source/GIGUtils/Image/ImageDownloader.swift
@@ -55,7 +55,9 @@ struct ImageDownloader {
 	
 	private func downloadNext() {
 		guard let view = ImageDownloader.stack.popLast() else { return }
-		guard let request = ImageDownloader.queue[view] else { return }
+		guard let request = ImageDownloader.queue[view] else {
+            self.downloadNext()
+            return }
 		
 		request.fetch { response in
 			switch response.status {

--- a/Source/GIGUtils/Image/ImageExtension.swift
+++ b/Source/GIGUtils/Image/ImageExtension.swift
@@ -12,11 +12,7 @@ import ImageIO
 public extension UIImageView {
 	
 	public func imageFromURL(urlString: String, placeholder: UIImage?) {
-		if urlString.contains("gif") {
-			loadGif(urlString: urlString)
-		} else {
-			ImageDownloader.shared.download(url: urlString, for: self, placeholder: placeholder)
-		}
+        ImageDownloader.shared.download(url: urlString, for: self, placeholder: placeholder)
 	}
 	
 	func loadGif(name: String) {

--- a/Source/SwiftNetwork/Response.swift
+++ b/Source/SwiftNetwork/Response.swift
@@ -216,6 +216,9 @@ public extension Response {
     }
     
     private func isGifData() -> Bool {
-        return url?.absoluteString.contains("gif") ?? false
+        guard let url = url else {
+            return false
+        }
+        return url.pathExtension == "gif"
     }
 }

--- a/Source/SwiftNetwork/Response.swift
+++ b/Source/SwiftNetwork/Response.swift
@@ -199,12 +199,23 @@ public extension Response {
 		guard let imageData = self.body else {
 			throw ResponseError.bodyNil
 		}
-		
-		guard let image = UIImage(data: imageData, scale: UIScreen.main.scale) else {
-			throw ResponseError.unexpectedDataType
-		}
-		
-		return image
+        guard !isGifData(), let image = UIImage(data: imageData, scale: UIScreen.main.scale) else {
+            throw ResponseError.unexpectedDataType
+        }
+        return image
 	}
 	
+    public func gif() throws -> UIImage {
+        guard let imageData = self.body else {
+            throw ResponseError.bodyNil
+        }
+        guard isGifData(), let imageGif = UIImage.gif(data: imageData) else {
+            throw ResponseError.unexpectedDataType
+        }
+        return imageGif
+    }
+    
+    private func isGifData() -> Bool {
+        return url?.absoluteString.contains("gif") ?? false
+    }
 }

--- a/Source/UIComponents/SlideMenu/Private/SlideMenuConfig.swift
+++ b/Source/UIComponents/SlideMenu/Private/SlideMenuConfig.swift
@@ -17,5 +17,5 @@ class SlideMenuConfig {
     var menuBackgroundColor: UIColor = UIColor.black
     var menuHighlightColor: UIColor?
     var menuTitleColor: UIColor?
-	
+    var menuSectionBasedStatusBarStyle: Bool = false
 }

--- a/Source/UIComponents/SlideMenu/Private/SlideMenuTableVC.swift
+++ b/Source/UIComponents/SlideMenu/Private/SlideMenuTableVC.swift
@@ -55,7 +55,8 @@ class SlideMenuTableVC: UIViewController, UITableViewDataSource, UITableViewDele
 		guard self.tableView != nil else {
 			return
 		}
-		
+        self.setNeedsStatusBarAppearanceUpdate()
+
 		let indexPath = IndexPath(row: index, section: 0)
         guard let modeButtonType = menuSectionClicked?.modeButtonType else {
             self.tableView.selectRow(at: indexPath, animated: true, scrollPosition: UITableViewScrollPosition.none)

--- a/Source/UIComponents/SlideMenu/Private/SlideMenuVC.swift
+++ b/Source/UIComponents/SlideMenu/Private/SlideMenuVC.swift
@@ -107,9 +107,12 @@ class SlideMenuVC: UIViewController, MenuTableDelegate, UIGestureRecognizerDeleg
 	
 	
 	override var preferredStatusBarStyle : UIStatusBarStyle {
-		return self.statusBarStyle
+        if SlideMenuConfig.shared.menuSectionBasedStatusBarStyle {
+            return self.currentController?.preferredStatusBarStyle ?? self.statusBarStyle
+        } else {
+            return self.statusBarStyle
+        }
 	}
-    
     
     // MARK: - Public Methods
     

--- a/Source/UIComponents/SlideMenu/SlideMenu.swift
+++ b/Source/UIComponents/SlideMenu/SlideMenu.swift
@@ -35,6 +35,12 @@ open class SlideMenu {
         }
     }
     
+    open var menuSectionBasedStatusBarStyle: Bool = false {
+        didSet {
+            SlideMenuConfig.shared.menuSectionBasedStatusBarStyle = self.menuSectionBasedStatusBarStyle
+        }
+    }
+    
     fileprivate lazy var menuViewController = SlideMenuVC.menuVC()
     fileprivate var sections: [MenuSection] = []
     
@@ -58,7 +64,6 @@ open class SlideMenu {
     open func userDidTapMenu() {
         self.menuViewController?.userDidTapMenuButton()
     }
-
     
     open func addSection(_ section: MenuSection) {
         self.sections.append(section)


### PR DESCRIPTION
For swift 4.2 setting the application statusBarStyle is now deprecated, making it necessary to use the preferredStatusBarStyle property on UIViewControllers. The following PR adds support for setting this property for view controllers associated to SlideMenu's sections.

This fix allows users of the SlideMenu to support "view controller-based status bar appearance" overriding the preferredStatusBarStyle property and comply to swift 4.2 expected usage.

By setting SlideMenu's property menuSectionBasedStatusBarStyle to true, the sections ViewControllers can decide how their status bar should appear.